### PR TITLE
Fix battery sim issues

### DIFF
--- a/project/src/main/java/org/ironmaple/simulation/drivesims/SwerveModuleSimulation.java
+++ b/project/src/main/java/org/ironmaple/simulation/drivesims/SwerveModuleSimulation.java
@@ -506,14 +506,15 @@ public class SwerveModuleSimulation {
 
         driveMotorAppliedVoltage = SimulatedBattery.clamp(driveMotorAppliedVoltage);
 
-        driveMotorAppliedVoltage = Volts.of(
-                MathUtil.applyDeadband(driveMotorAppliedVoltage.in(Volts), DRIVE_FRICTION_VOLTAGE.in(Volts), 12));
-
         /* calculate the stator current */
         driveMotorStatorCurrent = driveMotorConfigs.calculateCurrent(driveWheelFinalSpeed, driveMotorAppliedVoltage);
 
         /* calculate the torque generated */
-        return driveMotorConfigs.calculateTorque(driveMotorStatorCurrent).in(NewtonMeters);
+        Torque driveWheelTorque = driveMotorConfigs.calculateTorque(driveMotorStatorCurrent);
+
+        /* calculates the torque if you included losses from friction */
+        Torque driveWheelTorqueWithFriction = NewtonMeters.of(MathUtil.applyDeadband(driveWheelTorque.in(NewtonMeters), driveMotorConfigs.friction.in(NewtonMeters), Double.POSITIVE_INFINITY));
+        return driveWheelTorqueWithFriction.in(NewtonMeters);
     }
 
     /** @return the current module state of this simulation module */

--- a/project/src/main/java/org/ironmaple/simulation/motorsims/MapleMotorSim.java
+++ b/project/src/main/java/org/ironmaple/simulation/motorsims/MapleMotorSim.java
@@ -41,7 +41,7 @@ public class MapleMotorSim {
         this.appliedVoltage = Volts.zero();
         this.statorCurrent = Amps.zero();
 
-        SimulatedBattery.getInstance().addMotor(this);
+        SimulatedBattery.addMotor(this);
     }
 
     /**
@@ -57,6 +57,7 @@ public class MapleMotorSim {
                 state.mechanismAngularVelocity,
                 state.mechanismAngularPosition.times(configs.gearing),
                 state.mechanismAngularVelocity.times(configs.gearing));
+        this.appliedVoltage = SimulatedBattery.clamp(appliedVoltage);
         this.statorCurrent = configs.calculateCurrent(state.mechanismAngularVelocity, appliedVoltage);
         this.state.step(configs.calculateTorque(statorCurrent), configs.friction, configs.loadMOI, dt);
 
@@ -169,7 +170,7 @@ public class MapleMotorSim {
         // Hence,
         // Battery Voltage x Supply Current = Applied Voltage x Stator Current
         // Supply Current = Stator Current * Applied Voltage / Battery Voltage
-        return getStatorCurrent().times(appliedVoltage.div(Volts.of(12)));
+        return getStatorCurrent().times(appliedVoltage.div(SimulatedBattery.getBatteryVoltage()));
     }
 
     /**

--- a/project/src/main/java/org/ironmaple/simulation/motorsims/SimulatedBattery.java
+++ b/project/src/main/java/org/ironmaple/simulation/motorsims/SimulatedBattery.java
@@ -52,6 +52,11 @@ public class SimulatedBattery {
         return Volts.of(batteryVoltageVolts);
     }
     
+    /**
+     * Clamps the voltage to be a voltage between - battery voltage and + battery voltage.
+     * @param voltage
+     * @return
+     */
     public static Voltage clamp(Voltage voltage) {
         return Volts.of(
             MathUtil.clamp(voltage.in(Volts), -batteryVoltageVolts, batteryVoltageVolts)


### PR DESCRIPTION
# Modify an incorrect friction clamping and fix MapleMotorSim clamping

MapleMotorSim did not integrate proper clamping at all and always compared its output voltage to 12 volts no matter what.

Additionally there was an error in one of the classes where you still used .instance().

I tested it in sim and it worked wonderfully. Battery voltage never dropped below 9.5 (reasonable during full acceleration) and the battery went up to around 12.9 during deceleration due to regenerative breaking.